### PR TITLE
feat(core): add runtime schema descriptor with property tracking (#11)

### DIFF
--- a/apps/docs/content/docs/reference/core.mdx
+++ b/apps/docs/content/docs/reference/core.mdx
@@ -237,6 +237,95 @@ type MySchema = {
 The schema type is used for compile-time type checking only. It doesn't create database tables.
 </Callout>
 
+## Runtime Schema Descriptor
+
+For runtime entity discovery and metadata attachment, use `defineSchema()` to create a schema descriptor:
+
+### `defineSchema<S>(entities): SchemaDescriptor<S>`
+
+Creates a runtime schema descriptor that provides entity discovery, property discovery, and extensible metadata attachment.
+
+```ts
+import { defineSchema } from '@rippledb/core';
+
+const schema = defineSchema({
+  todos: { id: '', title: '', done: false },
+  users: { id: '', name: '', email: '' },
+});
+
+// Runtime entity discovery
+schema.entities; // ['todos', 'users']
+schema.entityMap.has('todos'); // true
+
+// Runtime property discovery
+schema.getFields('todos'); // ['id', 'title', 'done']
+schema.hasField('todos', 'title'); // true
+schema.hasField('todos', 'missing'); // false
+
+// Type inference still works
+type MySchema = typeof schema.schema;
+const db = new SqliteDb<MySchema>({ filename: './data.db' });
+```
+
+**Note:** The values in the entity objects are used to infer field names at runtime. Use sample/default values (empty strings, `false`, `0`, etc.) that match your TypeScript types.
+
+### Schema Descriptor API
+
+```ts
+type SchemaDescriptor<S extends RippleSchema> = {
+  // Original schema (for type inference and runtime introspection)
+  readonly schema: S;
+  
+  // Array of entity names for runtime discovery
+  readonly entities: readonly EntityName<S>[];
+  
+  // Map for O(1) entity lookup
+  readonly entityMap: ReadonlyMap<EntityName<S>, true>;
+  
+  // Map of entity names to their field names
+  readonly entityFields: ReadonlyMap<EntityName<S>, readonly string[]>;
+  
+  // Get field names for a specific entity
+  getFields<E extends EntityName<S>>(entity: E): readonly string[];
+  
+  // Check if an entity has a specific field
+  hasField<E extends EntityName<S>>(entity: E, field: string): boolean;
+  
+  // Extensible metadata (Zod schemas, Drizzle tables, etc.)
+  readonly extensions: ReadonlyMap<string, SchemaExtension>;
+  
+  // Attach metadata extensions
+  extend<K extends string, E extends SchemaExtension>(
+    key: K,
+    extension: E,
+  ): SchemaDescriptor<S>;
+};
+```
+
+### Extensions
+
+Extensions allow adapters to attach metadata to schema descriptors:
+
+```ts
+// Example: Attach Zod schemas (future @rippledb/zod integration)
+const schemaWithZod = schema.extend('zod', {
+  todos: z.object({ id: z.string(), title: z.string() }),
+  users: z.object({ id: z.string(), name: z.string() }),
+});
+
+// Example: Attach Drizzle table mappings (future integration)
+const schemaWithDrizzle = schema.extend('drizzle', {
+  tableMap: { todos: todosTable, users: usersTable },
+});
+```
+
+### Use Cases
+
+- **Controllers / client-query**: Build `api.todos`, `api.users` dynamically from `descriptor.entities`
+- **Zod validation**: Attach schemas for per-entity validation (see [issue #7](https://github.com/eckerlein/rippledb/issues/7))
+- **Drizzle adapters**: Attach table definitions as single source of truth
+- **Materializers**: Read `tableMap` from descriptor instead of separate config
+
 ## Related
 
 - [Core Concepts](/docs/getting-started/concepts) — Understand HLCs and Changes

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './change';
 export type { Hlc, ParsedHlc, HlcState } from './hlc';
 export { compareHlc, createHlcState, formatHlc, observeHlc, parseHlc, tickHlc } from './hlc';
+export * from './schema';
 

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { defineSchema } from './schema';
+
+describe('defineSchema', () => {
+  it('creates a schema descriptor with entity discovery', () => {
+    const schema = defineSchema({
+      todos: { id: '', title: '', done: false },
+      users: { id: '', name: '', email: '' },
+    });
+
+    expect(schema.entities).toEqual(['todos', 'users']);
+    expect(schema.entityMap.has('todos')).toBe(true);
+    expect(schema.entityMap.has('users')).toBe(true);
+    // @ts-expect-error - testing invalid entity name
+    expect(schema.entityMap.has('comments')).toBe(false);
+  });
+
+  it('tracks entity properties at runtime', () => {
+    const schema = defineSchema({
+      todos: { id: '', title: '', done: false },
+      users: { id: '', name: '', email: '' },
+    });
+
+    expect(schema.getFields('todos')).toEqual(['id', 'title', 'done']);
+    expect(schema.getFields('users')).toEqual(['id', 'name', 'email']);
+    // @ts-expect-error - testing invalid entity name
+    expect(schema.getFields('comments')).toEqual([]);
+  });
+
+  it('can check if entity has a field', () => {
+    const schema = defineSchema({
+      todos: { id: '', title: '', done: false },
+      users: { id: '', name: '', email: '' },
+    });
+
+    expect(schema.hasField('todos', 'title')).toBe(true);
+    expect(schema.hasField('todos', 'done')).toBe(true);
+    expect(schema.hasField('todos', 'missing')).toBe(false);
+    expect(schema.hasField('users', 'email')).toBe(true);
+    expect(schema.hasField('users', 'title')).toBe(false);
+  });
+
+  it('preserves schema type for type inference', () => {
+    const schema = defineSchema({
+      todos: { id: '', title: '', done: false },
+      users: { id: '', name: '', email: '' },
+    });
+
+    // Type check: schema.schema should preserve the structure
+    type InferredSchema = typeof schema.schema;
+    const _test: InferredSchema = schema.schema;
+    expect(_test).toBeDefined();
+    expect(_test.todos).toBeDefined();
+    expect(_test.users).toBeDefined();
+    expect(_test.todos.id).toBeDefined();
+    expect(_test.users.email).toBeDefined();
+  });
+
+  it('provides empty extensions map initially', () => {
+    const schema = defineSchema({
+      todos: { id: '', title: '' },
+    });
+
+    expect(schema.extensions.size).toBe(0);
+  });
+
+  it('allows attaching extensions', () => {
+    const schema = defineSchema({
+      todos: { id: '', title: '' },
+      users: { id: '', name: '' },
+    });
+
+    const zodExtension = {
+      todos: { parse: () => ({}) },
+      users: { parse: () => ({}) },
+    };
+
+    const schemaWithZod = schema.extend('zod', zodExtension);
+
+    expect(schemaWithZod.extensions.size).toBe(1);
+    expect(schemaWithZod.extensions.get('zod')).toEqual(zodExtension);
+    expect(schemaWithZod.entities).toEqual(['todos', 'users']); // Preserves entities
+  });
+
+  it('allows multiple extensions', () => {
+    const schema = defineSchema({
+      todos: { id: '', title: '' },
+    });
+
+    const zodExtension = { todos: {} };
+    const drizzleExtension = { tableMap: { todos: 'todos_table' } };
+
+    const schemaWithBoth = schema
+      .extend('zod', zodExtension)
+      .extend('drizzle', drizzleExtension);
+
+    expect(schemaWithBoth.extensions.size).toBe(2);
+    expect(schemaWithBoth.extensions.get('zod')).toEqual(zodExtension);
+    expect(schemaWithBoth.extensions.get('drizzle')).toEqual(drizzleExtension);
+  });
+
+  it('preserves immutability of entities array', () => {
+    const schema = defineSchema({
+      todos: { id: '', title: '' },
+      users: { id: '', name: '' },
+    });
+
+    expect(() => {
+      (schema.entities as string[]).push('comments');
+    }).toThrow();
+  });
+
+  it('preserves immutability of fields array', () => {
+    const schema = defineSchema({
+      todos: { id: '', title: '', done: false },
+    });
+
+    const fields = schema.getFields('todos');
+    expect(() => {
+      (fields as string[]).push('newField');
+    }).toThrow();
+  });
+
+  it('works with single entity', () => {
+    const schema = defineSchema({
+      todos: { id: '', title: '' },
+    });
+
+    expect(schema.entities).toEqual(['todos']);
+    expect(schema.entityMap.size).toBe(1);
+    expect(schema.getFields('todos')).toEqual(['id', 'title']);
+  });
+
+  it('works with empty schema', () => {
+    const schema = defineSchema({});
+
+    expect(schema.entities).toEqual([]);
+    expect(schema.entityMap.size).toBe(0);
+  });
+});

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,0 +1,177 @@
+import type { RippleSchema, EntityName } from './change';
+
+/**
+ * Extension metadata that can be attached to schema descriptors.
+ * Extensions are keyed by extension name and can contain arbitrary data.
+ */
+export type SchemaExtension = Record<string, unknown>;
+
+/**
+ * Runtime schema descriptor that provides entity discovery and extensible metadata.
+ * 
+ * This is the canonical hub for:
+ * - Entity discovery (runtime list of entities)
+ * - Property/field discovery (runtime list of fields per entity)
+ * - Metadata attachment (Zod schemas, Drizzle tables, field maps, etc.)
+ * - Type inference (still driven by TS generics, but descriptor is typed)
+ * 
+ * @example
+ * ```ts
+ * const schema = defineSchema({
+ *   todos: { id: '', title: '', done: false },
+ *   users: { id: '', name: '', email: '' },
+ * });
+ * 
+ * // Runtime entity discovery
+ * schema.entities; // ['todos', 'users']
+ * 
+ * // Runtime property discovery
+ * schema.getFields('todos'); // ['id', 'title', 'done']
+ * 
+ * // Type-safe access
+ * type MySchema = typeof schema.schema;
+ * ```
+ */
+export type SchemaDescriptor<
+  S extends RippleSchema = RippleSchema,
+> = {
+  /**
+   * The original schema object (for type inference and runtime introspection).
+   */
+  readonly schema: S;
+  
+  /**
+   * Array of entity names for runtime discovery.
+   */
+  readonly entities: readonly EntityName<S>[];
+  
+  /**
+   * Map of entity names to entity names (for O(1) lookup).
+   */
+  readonly entityMap: ReadonlyMap<EntityName<S>, true>;
+  
+  /**
+   * Map of entity names to their field names.
+   */
+  readonly entityFields: ReadonlyMap<EntityName<S>, readonly string[]>;
+  
+  /**
+   * Get field names for a specific entity.
+   * 
+   * @param entity - The entity name
+   * @returns Array of field names, or empty array if entity not found
+   */
+  getFields<E extends EntityName<S>>(entity: E): readonly string[];
+  
+  /**
+   * Check if an entity has a specific field.
+   * 
+   * @param entity - The entity name
+   * @param field - The field name
+   * @returns True if the entity has the field
+   */
+  hasField<E extends EntityName<S>>(entity: E, field: string): boolean;
+  
+  /**
+   * Extensible metadata attached to this schema descriptor.
+   * Extensions can be added by adapters (Zod, Drizzle, etc.).
+   */
+  readonly extensions: ReadonlyMap<string, SchemaExtension>;
+  
+  /**
+   * Attach metadata to this schema descriptor.
+   * Returns a new descriptor with the extension added.
+   * 
+   * @example
+   * ```ts
+   * const schemaWithZod = schema.extend('zod', {
+   *   todos: z.object({ id: z.string(), title: z.string() }),
+   * });
+   * ```
+   */
+  extend<K extends string, E extends SchemaExtension>(
+    key: K,
+    extension: E,
+  ): SchemaDescriptor<S>;
+};
+
+/**
+ * Creates a runtime schema descriptor from entity definitions.
+ * 
+ * The descriptor provides runtime entity and property discovery while maintaining
+ * full TypeScript type safety through generics.
+ * 
+ * @param entities - Object where keys are entity names and values are sample objects
+ *                   with all properties (values are used to infer field names at runtime)
+ * @returns A typed schema descriptor with runtime entity and property discovery
+ * 
+ * @example
+ * ```ts
+ * const schema = defineSchema({
+ *   todos: { id: '', title: '', done: false },
+ *   users: { id: '', name: '', email: '' },
+ * });
+ * 
+ * // Runtime entity discovery
+ * for (const entity of schema.entities) {
+ *   console.log(entity); // 'todos', 'users'
+ * }
+ * 
+ * // Runtime property discovery
+ * schema.getFields('todos'); // ['id', 'title', 'done']
+ * schema.hasField('todos', 'title'); // true
+ * 
+ * // Type inference still works
+ * type MySchema = typeof schema.schema;
+ * const db = new SqliteDb<MySchema>({ ... });
+ * ```
+ */
+export function defineSchema<S extends RippleSchema>(
+  entities: S,
+): SchemaDescriptor<S> {
+  const entityNames = Object.keys(entities) as EntityName<S>[];
+  const entityMap = new Map<EntityName<S>, true>();
+  const entityFields = new Map<EntityName<S>, readonly string[]>();
+  
+  for (const name of entityNames) {
+    entityMap.set(name, true);
+    
+    // Extract field names from the entity object
+    const entityValue = entities[name];
+    const fields = Object.keys(entityValue) as readonly string[];
+    entityFields.set(name, Object.freeze(fields));
+  }
+  
+  const extensions = new Map<string, SchemaExtension>();
+  
+  return {
+    schema: entities,
+    entities: Object.freeze(entityNames) as readonly EntityName<S>[],
+    entityMap: Object.freeze(entityMap) as ReadonlyMap<EntityName<S>, true>,
+    entityFields: Object.freeze(entityFields) as ReadonlyMap<EntityName<S>, readonly string[]>,
+    
+    getFields<E extends EntityName<S>>(entity: E): readonly string[] {
+      return entityFields.get(entity) ?? [];
+    },
+    
+    hasField<E extends EntityName<S>>(entity: E, field: string): boolean {
+      const fields = entityFields.get(entity) ?? [];
+      return fields.includes(field);
+    },
+    
+    extensions: Object.freeze(extensions) as ReadonlyMap<string, SchemaExtension>,
+    
+    extend<K extends string, E extends SchemaExtension>(
+      key: K,
+      extension: E,
+    ): SchemaDescriptor<S> {
+      const newExtensions = new Map(this.extensions);
+      newExtensions.set(key, extension);
+      
+      return {
+        ...this,
+        extensions: Object.freeze(newExtensions) as ReadonlyMap<string, SchemaExtension>,
+      };
+    },
+  };
+}


### PR DESCRIPTION
Implements runtime schema descriptor as described in issue #11.

## Changes

- Added `defineSchema()` function in `@rippledb/core` that returns a typed runtime descriptor
- **Tracks entity names AND properties at runtime** (new!)
- Descriptor provides `entities` array, `entityMap`, and `entityFields` map
- Added `getFields(entity)` and `hasField(entity, field)` methods for property introspection
- Extensible metadata system via `extend()` method for attaching Zod schemas, Drizzle tables, etc.
- Full TypeScript type safety maintained - descriptor is typed by `RippleSchema`
- Comprehensive tests added (11 tests)
- Documentation updated in core reference

## Runtime Property Tracking

The descriptor now tracks the full schema at runtime:

```ts
const schema = defineSchema({
  todos: { id: '', title: '', done: false },
  users: { id: '', name: '', email: '' },
});

// Entity discovery
schema.entities; // ['todos', 'users']

// Property discovery
schema.getFields('todos'); // ['id', 'title', 'done']
schema.hasField('todos', 'title'); // true
schema.hasField('todos', 'missing'); // false
```

## Use Cases

- **Controllers / client-query**: Build `api.todos`, `api.users` dynamically from `descriptor.entities` and introspect properties
- **Zod validation**: Attach schemas for per-entity validation (enables #7)
- **Drizzle adapters**: Attach table definitions as single source of truth
- **Materializers**: Read `tableMap` from descriptor instead of separate config

## Testing

All tests pass (88 tests total, including 11 new schema tests).

Closes #11