### PR TITLE
Fix documentation: Update materializer API to match actual implementation

### DIFF
--- a/apps/docs/content/docs/adapters/db-sqlite.mdx
+++ b/apps/docs/content/docs/adapters/db-sqlite.mdx
@@ -44,19 +44,23 @@ To project changes into domain tables, add a materializer:
 
 ```ts
 import { SqliteDb } from '@rippledb/db-sqlite';
-import { createMaterializerConfig, SqliteDialect } from '@rippledb/materialize-db';
+import { createSyncSqlExecutor } from '@rippledb/materialize-db';
 
 const db = new SqliteDb<MySchema>({
   filename: './data.db',
-  materializer: ({ db }) =>
-    createMaterializerConfig({
-      db,
-      dialect: SqliteDialect,
+  materializer: ({ db }) => {
+    const sqlConfig = {
+      dialect: 'sqlite',
       tableMap: { todos: 'todos' },
       fieldMap: {
         todos: { id: 'id', title: 'title', done: 'done' },
       },
-    }),
+    } as const;
+    return {
+      ...sqlConfig,
+      executor: createSyncSqlExecutor(db, sqlConfig),
+    };
+  },
 });
 ```
 
@@ -110,13 +114,21 @@ Default: `['journal_mode = WAL']`
 Factory function that returns a materializer configuration. Called with `{ db }` containing the SQLite database instance.
 
 ```ts
+import { createSyncSqlExecutor } from '@rippledb/materialize-db';
+
 new SqliteDb({
   filename: './data.db',
-  materializer: ({ db }) => ({
-    tableMap: { todos: 'todos' },
-    fieldMap: { todos: { id: 'id', title: 'title', done: 'done' } },
-    executor: createSyncSqlExecutor(/* ... */),
-  }),
+  materializer: ({ db }) => {
+    const sqlConfig = {
+      dialect: 'sqlite',
+      tableMap: { todos: 'todos' },
+      fieldMap: { todos: { id: 'id', title: 'title', done: 'done' } },
+    } as const;
+    return {
+      ...sqlConfig,
+      executor: createSyncSqlExecutor(db, sqlConfig),
+    };
+  },
 });
 ```
 

--- a/apps/docs/content/docs/adapters/db-turso.mdx
+++ b/apps/docs/content/docs/adapters/db-turso.mdx
@@ -43,20 +43,24 @@ db.close();
 
 ```ts
 import { TursoDb } from '@rippledb/db-turso';
-import { createMaterializerConfig, SqliteDialect } from '@rippledb/materialize-db';
+import { createSqlExecutor } from '@rippledb/materialize-db';
 
 const db = new TursoDb<MySchema>({
   url: process.env.TURSO_DATABASE_URL!,
   authToken: process.env.TURSO_AUTH_TOKEN!,
-  materializer: ({ db }) =>
-    createMaterializerConfig({
-      db,
-      dialect: SqliteDialect,
+  materializer: ({ db }) => {
+    const sqlConfig = {
+      dialect: 'sqlite',
       tableMap: { todos: 'todos' },
       fieldMap: {
         todos: { id: 'id', title: 'title', done: 'done' },
       },
-    }),
+    } as const;
+    return {
+      ...sqlConfig,
+      executor: createSqlExecutor(sqlConfig, db),
+    };
+  },
 });
 ```
 

--- a/apps/docs/content/docs/adapters/materialize-db.mdx
+++ b/apps/docs/content/docs/adapters/materialize-db.mdx
@@ -36,20 +36,24 @@ SELECT * FROM todos WHERE id = 'todo-1';
 
 ```ts
 import { SqliteDb } from '@rippledb/db-sqlite';
-import { createMaterializerConfig, SqliteDialect } from '@rippledb/materialize-db';
+import { createSyncSqlExecutor } from '@rippledb/materialize-db';
 
 const db = new SqliteDb<MySchema>({
   filename: './data.db',
-  materializer: ({ db }) =>
-    createMaterializerConfig({
-      db,
-      dialect: SqliteDialect,
+  materializer: ({ db }) => {
+    const sqlConfig = {
+      dialect: 'sqlite',
       tableMap: { todos: 'todos', users: 'users' },
       fieldMap: {
         todos: { id: 'id', title: 'title', done: 'done' },
         users: { id: 'id', name: 'name', email: 'email' },
       },
-    }),
+    } as const;
+    return {
+      ...sqlConfig,
+      executor: createSyncSqlExecutor(db, sqlConfig),
+    };
+  },
 });
 ```
 
@@ -69,15 +73,20 @@ All happens atomically in the same transaction.
 
 Built-in SQL dialect. Currently supported:
 
-- `SqliteDialect` — For SQLite and Turso
+- `'sqlite'` — For SQLite and Turso
 
 ```ts
-import { SqliteDialect } from '@rippledb/materialize-db';
+import { createSyncSqlExecutor } from '@rippledb/materialize-db';
 
-createMaterializerConfig({
-  db,
-  dialect: SqliteDialect,
-  // ...
+const sqlConfig = {
+  dialect: 'sqlite',
+  tableMap: { todos: 'todos' },
+  fieldMap: { todos: { id: 'id', title: 'title', done: 'done' } },
+} as const;
+
+materializer: ({ db }) => ({
+  ...sqlConfig,
+  executor: createSyncSqlExecutor(db, sqlConfig),
 });
 ```
 
@@ -91,12 +100,17 @@ type MySchema = {
   users: { id: string; name: string };
 };
 
-createMaterializerConfig({
-  // ...
+const sqlConfig = {
+  dialect: 'sqlite',
   tableMap: {
     todos: 'todos',      // Entity 'todos' → table 'todos'
     users: 'app_users',  // Entity 'users' → table 'app_users'
   },
+} as const;
+
+materializer: ({ db }) => ({
+  ...sqlConfig,
+  executor: createSyncSqlExecutor(db, sqlConfig),
 });
 ```
 
@@ -105,8 +119,9 @@ createMaterializerConfig({
 Maps schema field names to database column names. If omitted, field names are used as-is.
 
 ```ts
-createMaterializerConfig({
-  // ...
+const sqlConfig = {
+  dialect: 'sqlite',
+  tableMap: { todos: 'todos' },
   fieldMap: {
     todos: {
       id: 'id',
@@ -114,6 +129,11 @@ createMaterializerConfig({
       done: 'is_done',  // Schema field 'done' → column 'is_done'
     },
   },
+} as const;
+
+materializer: ({ db }) => ({
+  ...sqlConfig,
+  executor: createSyncSqlExecutor(db, sqlConfig),
 });
 ```
 
@@ -126,9 +146,15 @@ If `fieldMap` is provided for an entity, changes to that entity will update the 
 Name of the table storing entity tags/metadata. Default: `'ripple_tags'`
 
 ```ts
-createMaterializerConfig({
-  // ...
+const sqlConfig = {
+  dialect: 'sqlite',
+  tableMap: { todos: 'todos' },
   tagsTable: 'my_ripple_tags',
+} as const;
+
+materializer: ({ db }) => ({
+  ...sqlConfig,
+  executor: createSyncSqlExecutor(db, sqlConfig),
 });
 ```
 
@@ -153,8 +179,9 @@ CREATE TABLE ripple_tags (
 For databases not covered by built-in dialects, provide custom SQL commands:
 
 ```ts
-createMaterializerConfig({
-  db,
+import { createSyncSqlExecutor } from '@rippledb/materialize-db';
+
+const sqlConfig = {
   tableMap: { todos: 'todos' },
   loadCommand: (tagsTable) => `
     SELECT data, tags, deleted, deleted_tag 
@@ -179,6 +206,11 @@ createMaterializerConfig({
       deleted = 1,
       deleted_tag = excluded.deleted_tag
   `,
+} as const;
+
+materializer: ({ db }) => ({
+  ...sqlConfig,
+  executor: createSyncSqlExecutor(db, sqlConfig),
 });
 ```
 
@@ -187,7 +219,7 @@ createMaterializerConfig({
 For full control, provide a custom executor:
 
 ```ts
-createMaterializerConfig({
+materializer: ({ db }) => ({
   tableMap: { todos: 'todos' },
   fieldMap: { todos: { id: 'id', title: 'title', done: 'done' } },
   executor: {
@@ -215,16 +247,39 @@ createMaterializerConfig({
 For SQLite with `better-sqlite3`, use the sync variants:
 
 ```ts
-import { createSyncMaterializer, createSyncSqlExecutor } from '@rippledb/materialize-db';
+import { createSyncSqlExecutor } from '@rippledb/materialize-db';
 
 // Sync executor for better-sqlite3
-const executor = createSyncSqlExecutor({
-  db,
-  dialect: SqliteDialect,
-  tagsTable: 'ripple_tags',
-  tableMap: { todos: 'todos' },
-  fieldMap: { todos: { id: 'id', title: 'title', done: 'done' } },
-});
+materializer: ({ db }) => {
+  const sqlConfig = {
+    dialect: 'sqlite',
+    tagsTable: 'ripple_tags',
+    tableMap: { todos: 'todos' },
+    fieldMap: { todos: { id: 'id', title: 'title', done: 'done' } },
+  } as const;
+  return {
+    ...sqlConfig,
+    executor: createSyncSqlExecutor(db, sqlConfig),
+  };
+}
+```
+
+For async databases (like Turso), use `createSqlExecutor`:
+
+```ts
+import { createSqlExecutor } from '@rippledb/materialize-db';
+
+materializer: ({ db }) => {
+  const sqlConfig = {
+    dialect: 'sqlite',
+    tableMap: { todos: 'todos' },
+    fieldMap: { todos: { id: 'id', title: 'title', done: 'done' } },
+  } as const;
+  return {
+    ...sqlConfig,
+    executor: createSqlExecutor(sqlConfig, db),
+  };
+}
 ```
 
 ## Domain Table Requirements

--- a/apps/docs/content/docs/getting-started/quick-start.mdx
+++ b/apps/docs/content/docs/getting-started/quick-start.mdx
@@ -56,21 +56,23 @@ Create `src/db.ts` to configure your RippleDB database:
 
 ```ts title="src/db.ts"
 import { SqliteDb } from '@rippledb/db-sqlite';
-import { createMaterializerConfig, SqliteDialect } from '@rippledb/materialize-db';
+import { createSyncSqlExecutor } from '@rippledb/materialize-db';
 import type { TodosSchema } from './schema';
 
 // Create the database with a materializer
 export const db = new SqliteDb<TodosSchema>({
   filename: './data.db',
-  materializer: ({ db }) =>
-    createMaterializerConfig({
-      db,
-      dialect: SqliteDialect,
+  materializer: ({ db }) => {
+    const sqlConfig = {
+      dialect: 'sqlite',
       tableMap: { todos: 'todos' },
-      fieldMap: {
-        todos: { id: 'id', title: 'title', done: 'done' },
-      },
-    }),
+      fieldMap: { todos: { id: 'id', title: 'title', done: 'done' } },
+    } as const;
+    return {
+      ...sqlConfig,
+      executor: createSyncSqlExecutor(db, sqlConfig),
+    };
+  },
 });
 ```
 </Step>
@@ -116,7 +118,7 @@ async function main() {
     hlc: hlc(),
   });
 
-  await db.append(stream, [createTodo]);
+  await db.append({ stream, changes: [createTodo] });
   console.log('Created todo:', createTodo);
 
   // Update the todo
@@ -128,13 +130,13 @@ async function main() {
     hlc: hlc(),
   });
 
-  await db.append(stream, [updateTodo]);
+  await db.append({ stream, changes: [updateTodo] });
   console.log('Updated todo:', updateTodo);
 
   // Pull all changes
-  const { changes, cursor } = await db.pull(stream, null);
+  const { changes, nextCursor } = await db.pull({ stream, cursor: null });
   console.log('All changes:', changes);
-  console.log('Cursor for next pull:', cursor);
+  console.log('Cursor for next pull:', nextCursor);
 
   // Delete the todo
   const deleteTodo = makeDelete<TodosSchema>({
@@ -144,7 +146,7 @@ async function main() {
     hlc: hlc(),
   });
 
-  await db.append(stream, [deleteTodo]);
+  await db.append({ stream, changes: [deleteTodo] });
   console.log('Deleted todo');
 
   db.close();

--- a/apps/docs/content/docs/guides/materialization.mdx
+++ b/apps/docs/content/docs/guides/materialization.mdx
@@ -137,16 +137,21 @@ When a change arrives, each field is compared independently:
 
 ```ts
 import { SqliteDb } from '@rippledb/db-sqlite';
-import { createMaterializerConfig, SqliteDialect } from '@rippledb/materialize-db';
+import { createSyncSqlExecutor } from '@rippledb/materialize-db';
 
 const db = new SqliteDb<MySchema>({
   filename: './data.db',
-  materializer: ({ db }) => createMaterializerConfig({
-    db,
-    dialect: SqliteDialect,
-    tableMap: { todos: 'todos' },
-    fieldMap: { todos: { id: 'id', title: 'title', done: 'done' } },
-  }),
+  materializer: ({ db }) => {
+    const sqlConfig = {
+      dialect: 'sqlite',
+      tableMap: { todos: 'todos' },
+      fieldMap: { todos: { id: 'id', title: 'title', done: 'done' } },
+    } as const;
+    return {
+      ...sqlConfig,
+      executor: createSyncSqlExecutor(db, sqlConfig),
+    };
+  },
 });
 ```
 

--- a/apps/docs/content/docs/guides/server-setup.mdx
+++ b/apps/docs/content/docs/guides/server-setup.mdx
@@ -91,7 +91,7 @@ In a distributed setup, each server instance needs a unique `NODE_ID`.
   <Tab value="SQLite">
 ```ts title="src/db.ts"
 import { SqliteDb } from '@rippledb/db-sqlite';
-import { createMaterializerConfig, SqliteDialect } from '@rippledb/materialize-db';
+import { createSyncSqlExecutor } from '@rippledb/materialize-db';
 import type { AppSchema } from './schema';
 
 // Create domain tables
@@ -113,9 +113,8 @@ const db = new SqliteDb<AppSchema>({
       );
     `);
 
-    return createMaterializerConfig({
-      db,
-      dialect: SqliteDialect,
+    const sqlConfig = {
+      dialect: 'sqlite',
       tableMap: {
         todos: 'todos',
         users: 'users',
@@ -124,7 +123,12 @@ const db = new SqliteDb<AppSchema>({
         todos: { id: 'id', title: 'title', done: 'done', createdAt: 'createdAt' },
         users: { id: 'id', name: 'name', email: 'email' },
       },
-    });
+    } as const;
+
+    return {
+      ...sqlConfig,
+      executor: createSyncSqlExecutor(db, sqlConfig),
+    };
   },
 });
 
@@ -134,24 +138,30 @@ export { db };
   <Tab value="Turso">
 ```ts title="src/db.ts"
 import { TursoDb } from '@rippledb/db-turso';
-import { createMaterializerConfig, SqliteDialect } from '@rippledb/materialize-db';
+import { createSqlExecutor } from '@rippledb/materialize-db';
 import type { AppSchema } from './schema';
 
 const db = new TursoDb<AppSchema>({
   url: process.env.TURSO_DATABASE_URL!,
   authToken: process.env.TURSO_AUTH_TOKEN!,
-  materializer: ({ db }) => createMaterializerConfig({
-    db,
-    dialect: SqliteDialect,
-    tableMap: {
-      todos: 'todos',
-      users: 'users',
-    },
-    fieldMap: {
-      todos: { id: 'id', title: 'title', done: 'done', createdAt: 'createdAt' },
-      users: { id: 'id', name: 'name', email: 'email' },
-    },
-  }),
+  materializer: ({ db }) => {
+    const sqlConfig = {
+      dialect: 'sqlite',
+      tableMap: {
+        todos: 'todos',
+        users: 'users',
+      },
+      fieldMap: {
+        todos: { id: 'id', title: 'title', done: 'done', createdAt: 'createdAt' },
+        users: { id: 'id', name: 'name', email: 'email' },
+      },
+    } as const;
+
+    return {
+      ...sqlConfig,
+      executor: createSqlExecutor(sqlConfig, db),
+    };
+  },
 });
 
 export { db };

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -41,22 +41,37 @@ This means:
 
 ```ts
 import { SqliteDb } from '@rippledb/db-sqlite';
-import { createMaterializerConfig } from '@rippledb/materialize-db';
+import { createSyncSqlExecutor } from '@rippledb/materialize-db';
+import { makeUpsert } from '@rippledb/core';
+import { tickHlc, createHlcState } from '@rippledb/core';
 
 const db = new SqliteDb({
   filename: './data.db',
-  materializer: ({ db }) => createMaterializerConfig({ db }),
+  materializer: ({ db }) => {
+    const sqlConfig = {
+      dialect: 'sqlite',
+      tableMap: { todos: 'todos' },
+      fieldMap: { todos: { id: 'id', title: 'title', done: 'done' } },
+    } as const;
+    return {
+      ...sqlConfig,
+      executor: createSyncSqlExecutor(db, sqlConfig),
+    };
+  },
 });
 
 // Append a change
-await db.append('my-stream', [{
-  entity: 'todos',
-  entityId: 'todo-1',
-  kind: 'upsert',
-  patch: { title: 'Buy milk', done: false },
-  tags: { title: hlc(), done: hlc() },
-  hlc: hlc(),
-}]);
+const hlc = tickHlc(createHlcState('node-1'), Date.now());
+await db.append({
+  stream: 'my-stream',
+  changes: [makeUpsert({
+    stream: 'my-stream',
+    entity: 'todos',
+    entityId: 'todo-1',
+    patch: { id: 'todo-1', title: 'Buy milk', done: false },
+    hlc,
+  })],
+});
 ```
 
 ## Get Started


### PR DESCRIPTION
This PR fixes the documentation to match the actual materializer API implementation.

## Changes

- Replaced `createMaterializerConfig` and `SqliteDialect` (which don't exist) with the actual API pattern
- Updated all examples to use the factory pattern:
  - SQLite: `createSyncSqlExecutor(db, sqlConfig)`
  - Turso: `createSqlExecutor(sqlConfig, db)`
- Fixed `db.append()` and `db.pull()` calls to use object syntax
- Updated all affected documentation files

## Pattern

The materializer now correctly shows the factory pattern where:
- DB owns the transaction
- Factory receives transaction-bound DB
- Returns config with executor

## Files Updated

- `apps/docs/content/docs/getting-started/quick-start.mdx`
- `apps/docs/content/docs/guides/server-setup.mdx`
- `apps/docs/content/docs/adapters/materialize-db.mdx`
- `apps/docs/content/docs/adapters/db-sqlite.mdx`
- `apps/docs/content/docs/adapters/db-turso.mdx`
- `apps/docs/content/docs/guides/materialization.mdx`
- `apps/docs/content/docs/index.mdx`
- `README.md`

Fixes #29